### PR TITLE
🐛 Handle insertFragment after a line return

### DIFF
--- a/cypress/integration/get-transformed-value.ts
+++ b/cypress/integration/get-transformed-value.ts
@@ -40,11 +40,9 @@ context('Get transformed value', () => {
   it('Should handle line break', () => {
     cy.visit(Cypress.env('baseUrl') + '?hello%0Aworld');
     cy.get('[data-cy=input]').type('{enter}.');
-    cy.get('[data-cy=input]').then($el =>
-      expect($el[0].innerText).to.eq('hello\nworld\n.')
-    );
+    cy.get('[data-cy=input]').textEqual('hello\nworld\n. ');
     cy.get('[data-cy=parse]').click();
-    cy.get('[data-cy=result]').should('have.text', 'hello\nworld\n.');
+    cy.get('[data-cy=result]').textEqual('hello\nworld\n.');
   });
 
   it('Should handle <br/> linebreak', () => {

--- a/cypress/integration/insert-fragment.ts
+++ b/cypress/integration/insert-fragment.ts
@@ -228,5 +228,20 @@ context('Insert fragment', () => {
       cy.get('[data-cy=parse]').click({ force: true });
       cy.get('[data-cy=result]').should('have.text', 'hello\n:unicorn:');
     });
+
+    it('Be able to write text after emoji without deleting it', () => {
+      cy.get('[data-cy=input]').type('hello{enter}');
+      cy.get('[data-cy=insert-custom]').click();
+      cy.get('[data-cy=final] img').should('exist');
+      cy.get('[data-cy=input]').type('.');
+      cy.get('[data-cy=parse]').click({ force: true });
+      cy.get('[data-cy=result]').should('have.text', 'hello\n:unicorn: .');
+    });
+
+    it('Insert icon if no content', () => {
+      cy.get('[data-cy=insert-custom]').click();
+      cy.get('[data-cy=parse]').click({ force: true });
+      cy.get('[data-cy=result]').should('have.text', ':unicorn:');
+    });
   });
 });

--- a/cypress/integration/insert-fragment.ts
+++ b/cypress/integration/insert-fragment.ts
@@ -220,5 +220,13 @@ context('Insert fragment', () => {
       cy.get('[data-cy=parse]').click();
       cy.get('[data-cy=result]').should('have.text', 'hello :unicorn:');
     });
+
+    it('Handle inserting after a return to line', () => {
+      cy.get('[data-cy=input]').type('hello{enter}');
+      cy.get('[data-cy=insert-custom]').click();
+      cy.get('[data-cy=final] img').should('exist');
+      cy.get('[data-cy=parse]').click({ force: true });
+      cy.get('[data-cy=result]').should('have.text', 'hello\n:unicorn:');
+    });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,10 +33,11 @@ Cypress.Commands.add(
     const regexp = data
       .replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
       .replace(/\s/g, '(\\u00a0|\\s)');
+    const text = subject[0].innerText;
 
     expect(
-      new RegExp(`^${regexp}$`).test(subject.text()),
-      `textEqual("${data}", "${subject.text()}")`
+      new RegExp(`^${regexp}$`).test(text),
+      `textEqual("${data}", "${text}")`
     ).to.be.true;
 
     // whatever we return becomes the new subject

--- a/src/utils/fixCursorInsertion.ts
+++ b/src/utils/fixCursorInsertion.ts
@@ -32,6 +32,7 @@ export function fixCursorInsertion(
           previousChild &&
           previousElement &&
           previousChild === previousElement &&
+          previousElement.hasAttribute('data-rich-mentions') &&
           !previousElement.hasAttribute('data-integrity')
         ) {
           previousElement.appendChild(document.createTextNode(insertion));

--- a/src/utils/insertFragment.ts
+++ b/src/utils/insertFragment.ts
@@ -167,8 +167,30 @@ export function insertFragment<T>(
     }
   }
 
+  const insertAfterReturnToLine =
+    insertBeforeNode &&
+    insertBeforeNode.nodeName === 'DIV' &&
+    insertBeforeNode.childNodes.length === 1 &&
+    insertBeforeNode.firstChild?.nodeName === 'BR';
+
   // Insert it at chosen position
-  if (insertAfterNode && insertAfterNode !== inputElement) {
+  if (
+    insertBeforeNode &&
+    insertBeforeNode.firstChild &&
+    insertAfterReturnToLine
+  ) {
+    /**
+     * In case of inserting fragment after a line return
+     * We need to replace the <div></br></div> by <br/>{fragment}
+     * No spaces are needed to be add.
+     */
+    const br = document.createElement('br');
+
+    inputElement.insertBefore(br, insertBeforeNode);
+    inputElement.replaceChild(span, insertBeforeNode);
+    addSpaceAfter = false;
+    addSpaceBefore = false;
+  } else if (insertAfterNode && insertAfterNode !== inputElement) {
     inputElement.insertBefore(span, insertAfterNode.nextSibling);
   } else if (insertBeforeNode && insertBeforeNode !== inputElement) {
     inputElement.insertBefore(span, insertBeforeNode);

--- a/src/utils/insertFragment.ts
+++ b/src/utils/insertFragment.ts
@@ -181,7 +181,7 @@ export function insertFragment<T>(
   ) {
     /**
      * In case of inserting fragment after a line return
-     * We need to replace the <div></br></div> by <br/>{fragment}
+     * We need to replace the <div><br/></div> by <br/>{fragment}
      * No spaces are needed to be add.
      */
     const br = document.createElement('br');

--- a/src/utils/insertFragment.ts
+++ b/src/utils/insertFragment.ts
@@ -167,30 +167,8 @@ export function insertFragment<T>(
     }
   }
 
-  const insertAfterReturnToLine =
-    insertBeforeNode &&
-    insertBeforeNode.nodeName === 'DIV' &&
-    insertBeforeNode.childNodes.length === 1 &&
-    insertBeforeNode.firstChild?.nodeName === 'BR';
-
   // Insert it at chosen position
-  if (
-    insertBeforeNode &&
-    insertBeforeNode.firstChild &&
-    insertAfterReturnToLine
-  ) {
-    /**
-     * In case of inserting fragment after a line return
-     * We need to replace the <div><br/></div> by <br/>{fragment}
-     * No spaces are needed to be add.
-     */
-    const br = document.createElement('br');
-
-    inputElement.insertBefore(br, insertBeforeNode);
-    inputElement.replaceChild(span, insertBeforeNode);
-    addSpaceAfter = false;
-    addSpaceBefore = false;
-  } else if (insertAfterNode && insertAfterNode !== inputElement) {
+  if (insertAfterNode && insertAfterNode !== inputElement) {
     inputElement.insertBefore(span, insertAfterNode.nextSibling);
   } else if (insertBeforeNode && insertBeforeNode !== inputElement) {
     inputElement.insertBefore(span, insertBeforeNode);

--- a/src/utils/removeBrokenFragments.ts
+++ b/src/utils/removeBrokenFragments.ts
@@ -1,10 +1,32 @@
 import { TMentionConfig } from '../RichMentionsContext';
+import { setCursorPosition } from './setCursorPosition';
 
 export function removeBrokenFragments<T>(
   inputElement: HTMLDivElement,
   configs: TMentionConfig<T>[]
 ) {
   Array.from(inputElement.children).forEach(element => {
+    /**
+     * https://github.com/koala-interactive/react-rich-mentions/pull/11
+     * When pressing enter, browsers adds <div><br/></div>
+     * This code removes the div and set the cursor after the <br/>
+     * To allow fragment insertion after the breakline.
+     */
+    if (
+      element instanceof HTMLDivElement &&
+      !element.attributes.length &&
+      element.childNodes.length === 1 &&
+      element.firstElementChild instanceof HTMLBRElement
+    ) {
+      const textNode = document.createTextNode('\u00A0');
+      const br = element.firstElementChild;
+      inputElement.insertBefore(br, element.nextSibling);
+      inputElement.insertBefore(textNode, br.nextSibling);
+      inputElement.removeChild(element);
+      setCursorPosition(textNode, 0);
+      return;
+    }
+
     // Chrome is adding empty div when pressing {enter} key
     // For now we can just allow it and keep it on the DOM
     if (


### PR DESCRIPTION
The case was when we wrote : `hello{enter}` then `insertFragment`, we would have a textContent like : 
`hello{fragment}<div><br/></div>`.
The fragment would be inserted before the `<div><br/></div>` line return of the div contentEditable, because the selection offset would be of value `0`. (Condition line 122 of `utils/insertFragment.ts`)

The code seems a bit rought around the edges, it will replace the `<div><br/></div>` by `<br/>{fragment}`, as a fragment inside a children `div` will not be found in `input.text` in cypress.

My first try was to replace insert `fragment` before the `br` in the div. However cypress tests couldn't asserts its text, it might be the best solution though.