### PR TITLE
Remove ci caching issues stemming from yarn arguments

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-cypress2-
 
-      - run: yarn --frozen-lockfile --prefer-offline
+      - run: yarn
         if: |
           steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
           steps.cache-node-modules.outputs.cache-hit != 'true' ||

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-nodemodules2-
 
-      - run: yarn --frozen-lockfile --prefer-offline
+      - run: yarn
         if: |
           steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
           steps.cache-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
The frozen-lockfile arguments was creating caching issues within our CI