### PR TITLE
🐛 This should fixes key combination

### DIFF
--- a/cypress/integration/pending-fragment.ts
+++ b/cypress/integration/pending-fragment.ts
@@ -103,7 +103,8 @@ context('Pending fragment', () => {
       });
 
     cy.get('[data-cy=input]').type('@');
-    cy.get('[data-cy=input]').textEqual('@ f');
+    cy.get('[data-cy=input]').textEqual('@f');
+    cy.get('[data-cy=autocomplete]').should('not.exist', 1);
   });
 
   it('Should be able to autocomplete and reuse already typed "@"', () => {

--- a/src/RichMentionsProvider.tsx
+++ b/src/RichMentionsProvider.tsx
@@ -148,7 +148,7 @@ export function RichMentionsProvider<T = object>({
     // If there is text selection, delete it.
     // We need to do it manually because of the preventDefault() :'(
     // Update 'text' variable as the content could be updated
-    if (deleteSelection(selection)) {
+    if (deleteSelection(selection, event)) {
       selection = document.getSelection();
       if (!selection || !selection.anchorNode) {
         return;

--- a/src/utils/deleteSelection.ts
+++ b/src/utils/deleteSelection.ts
@@ -1,5 +1,11 @@
-export function deleteSelection(selection: Selection): boolean {
+import { setCursorPosition } from './setCursorPosition';
+
+export function deleteSelection(
+  selection: Selection,
+  event?: React.FormEvent<HTMLDivElement>
+): boolean {
   let deleted = false;
+  let lastDeletedRange = null;
 
   for (let i = 0; i < selection.rangeCount; ++i) {
     const range = selection.getRangeAt(i);
@@ -9,8 +15,18 @@ export function deleteSelection(selection: Selection): boolean {
       range.startOffset !== range.endOffset
     ) {
       deleted = true;
+      lastDeletedRange = range;
       range.deleteContents();
     }
+  }
+
+  // @ts-ignore
+  if (event?.data && lastDeletedRange) {
+    // @ts-ignore
+    const textNode = document.createTextNode(event.data);
+    lastDeletedRange.insertNode(textNode);
+    setCursorPosition(textNode, 1);
+    event.preventDefault();
   }
 
   return deleted;


### PR DESCRIPTION
By writing "^" following with "o" it should write "ô", but for now it just delete the character, this fixes it.

Note : I can't write test as Cypress doesn't merge character when doing `.type("^o")`